### PR TITLE
Initial set of changes to move to Rocky Linux 9 platform

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -10,7 +10,7 @@ on:
 jobs:
 
   list-scenarios:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.listscenarios.outputs.scenarios }}
     steps:
@@ -22,7 +22,7 @@ jobs:
     name: Test
     needs:
       - list-scenarios
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       # Keep running so we can see if other tests pass
       fail-fast: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 7
+        - 9
   namespace: ome
   role_name: selinux_utils
   galaxy_tags: ['selinux']

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,7 +9,12 @@ lint: |
     flake8
 platforms:
   - name: selinux-utils-docker
-    image: centos:7
+    image: eniocarboni/docker-rockylinux-systemd:9
+    cgroupns_mode: host
+    tmpfs:
+      - /sys/fs/cgroup
+    groups:
+      - extra_options
 provisioner:
   name: ansible
   lint:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,12 +27,23 @@
       {{ selinux_getenforce_st.stat.exists and
          selinux_getenforce.stdout != 'Disabled' }}
 
+- name : check rocky.repo file
+  stat:
+    path: /etc/yum.repos.d/rocky.repo
+  register: rockyrepo_name
+
+- name: system packages | Add CRB repository for RHEL
+  become: true
+  ansible.builtin.command:
+    subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
+  when: ansible_os_family == 'RedHat' and not rockyrepo_name.stat.exists
+
 - name: system packages | install selinux utilities
   become: true
   package:
     name:
-      - libselinux-python
-      - libsemanage-python
-      - policycoreutils-python
+      - libselinux-python3
+      - libsemanage-python3
+      - policycoreutils-python3
     state: present
   when: selinux_enabled


### PR DESCRIPTION
cc @khaledk2 @jburel 

Status:

1. The Rocky Linux 9 test is present and passing (refactored from the previous CentOS 7 test)
2. The Ubuntu 22.04 test is missing (there was no Ubuntu test previously either)