### PR TITLE
install requests < 2.32.0

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -38,6 +38,7 @@ jobs:
             pip install "ansible<8" "ansible-lint<6.13" flake8
             pip install "molecule<5" "ansible-compat<4"
             pip install molecule-plugins[docker] pytest-testinfra
+            pip install "requests < 2.32.0"
       - name: Run molecule
         run: molecule test -s "${{ matrix.scenario }}"
 


### PR DESCRIPTION
This PR fix install request version < 2.32.0 to avoid the following request 2.32.0 bug  https://github.com/docker/docker-py/issues/3256
 
This leads to the throw the following error message: 

`Not supported URL scheme http+docker`

and  accordingly, the action failed 
